### PR TITLE
fix: stdio_client not starting in windows: getting NotImplementedError

### DIFF
--- a/app.py
+++ b/app.py
@@ -3,6 +3,10 @@ import asyncio
 import nest_asyncio
 import json
 import os
+import platform
+
+if platform.system() == "Windows":
+    asyncio.set_event_loop_policy(asyncio.WindowsProactorEventLoopPolicy())
 
 # Apply nest_asyncio to allow nested event loop calls within an already running event loop
 nest_asyncio.apply()

--- a/app_KOR.py
+++ b/app_KOR.py
@@ -3,6 +3,10 @@ import asyncio
 import nest_asyncio
 import json
 import os
+import platform
+
+if platform.system() == "Windows":
+    asyncio.set_event_loop_policy(asyncio.WindowsProactorEventLoopPolicy())
 
 # nest_asyncio 적용: 이미 실행 중인 이벤트 루프 내에서 중첩 호출 허용
 nest_asyncio.apply()


### PR DESCRIPTION
안녕하세요, 멋진 프로젝트 만들어 주셔서 감사합니다!

## 설명
이 PR은 Windows환경에서 streamlit run 으로 발생하는 예외에 대한 수정 요청 PR 입니다.
asyncio의 windows 동작 이슈로 추정됩니다.
검토 부탁드립니다. 🙇 

**예외 발생 재현 방법**

1. Windows 운영체제에서 streamlit 앱을 실행합니다.

```
uv venv
uv pip install -r requirements.txt
source .venv/bin/activate  # For Windows: .venv\Scripts\activate
streamlit run app_KOR.py
```

2. mcp 도구 올바르게 설정합니다.

3. 도구 적용하기 버튼을 누릅니다.

4. 예외가 발생합니다.
```
File "D:\GitHub\langgraph-mcp-agents\app_KOR.py", line 685, in <module>
    success = st.session_state.event_loop.run_until_complete(
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
File "d:\GitHub\langgraph-mcp-agents\.venv\Lib\site-packages\nest_asyncio.py", line 98, in run_until_complete
    return f.result()
           ^^^^^^^^^^
File "{USER_PATH}\AppData\Roaming\uv\python\cpython-3.12.8-windows-x86_64-none\Lib\asyncio\futures.py", line 202, in result
    raise self._exception.with_traceback(self._exception_tb)
File "{USER_PATH}\AppData\Roaming\uv\python\cpython-3.12.8-windows-x86_64-none\Lib\asyncio\tasks.py", line 314, in __step_run_and_handle_result
    result = coro.send(None)
             ^^^^^^^^^^^^^^^
File "D:\GitHub\langgraph-mcp-agents\app_KOR.py", line 357, in initialize_session
    await client.__aenter__()
File "d:\GitHub\langgraph-mcp-agents\.venv\Lib\site-packages\langchain_mcp_adapters\client.py", line 256, in __aenter__
    await self.connect_to_server_via_stdio(server_name, **connection_dict)
File "d:\GitHub\langgraph-mcp-agents\.venv\Lib\site-packages\langchain_mcp_adapters\client.py", line 196, in connect_to_server_via_stdio
    stdio_transport = await self.exit_stack.enter_async_context(stdio_client(server_params))
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
File "{USER_PATH}\AppData\Roaming\uv\python\cpython-3.12.8-windows-x86_64-none\Lib\contextlib.py", line 659, in enter_async_context
    result = await _enter(cm)
             ^^^^^^^^^^^^^^^^
File "{USER_PATH}\AppData\Roaming\uv\python\cpython-3.12.8-windows-x86_64-none\Lib\contextlib.py", line 210, in __aenter__
    return await anext(self.gen)
           ^^^^^^^^^^^^^^^^^^^^^
File "d:\GitHub\langgraph-mcp-agents\.venv\Lib\site-packages\mcp\client\stdio.py", line 100, in stdio_client
    process = await anyio.open_process(
              ^^^^^^^^^^^^^^^^^^^^^^^^^
File "d:\GitHub\langgraph-mcp-agents\.venv\Lib\site-packages\anyio\_core\_subprocesses.py", line 190, in open_process
    return await get_async_backend().open_process(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
File "d:\GitHub\langgraph-mcp-agents\.venv\Lib\site-packages\anyio\_backends\_asyncio.py", line 2561, in open_process
    process = await asyncio.create_subprocess_exec(
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
File "{USER_PATH}\AppData\Roaming\uv\python\cpython-3.12.8-windows-x86_64-none\Lib\asyncio\subprocess.py", line 224, in create_subprocess_exec
    transport, protocol = await loop.subprocess_exec(
                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^
File "{USER_PATH}\AppData\Roaming\uv\python\cpython-3.12.8-windows-x86_64-none\Lib\asyncio\base_events.py", line 1749, in subprocess_exec
    transport = await self._make_subprocess_transport(
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
File "{USER_PATH}\AppData\Roaming\uv\python\cpython-3.12.8-windows-x86_64-none\Lib\asyncio\base_events.py", line 523, in _make_subprocess_transport
    raise NotImplementedError
```


## 연관 이슈
https://github.com/modelcontextprotocol/python-sdk/issues/359


## 실행 환경
```
Python 3.12.8
uv 0.6.14
nest-asyncio              1.6.0
```